### PR TITLE
Implement power operator

### DIFF
--- a/Numbers.Tests/RationalShould.cs
+++ b/Numbers.Tests/RationalShould.cs
@@ -146,6 +146,11 @@ namespace Numbers.Tests
         public void RaiseToPower(Rational i, int j, Rational result)
             => Assert.Equal(result, i.ToPower(j));
 
+        [Theory]
+        [MemberData(nameof(GetPowerRaiseTestCases))]
+        public void RaiseToPowerUsingOperator(Rational i, int j, Rational result)
+            => Assert.Equal(result, i ^ j);
+
         public static IEnumerable<object[]> GetPowerRaiseTestCases()
         {
             yield return new object[] {One, 1, One};

--- a/Numbers/Rational.cs
+++ b/Numbers/Rational.cs
@@ -60,6 +60,8 @@ namespace Numbers
         public static Rational operator /(Rational i, Rational j)
             => new Rational(i.Numerator * j.Denominator, i.Denominator * j.Numerator);
 
+        public static Rational operator ^(Rational i, int j) => i.ToPower(j);
+
         public Rational ToPower(int i)
             => i > 0 ?
                 new Rational(this.Numerator.ToPower(i), this.Denominator.ToPower(i)) :


### PR DESCRIPTION
I'm not sure if we should do this, as unlike the other operators that
are simply doing the equivalent operation as they would on an int, in
this case we are repurposing an operator '^' that, in int world, is the
excusive or (XOR) operator. Having it do something completely different
here may confuse users, and it doesn't help that ints and rationals may
end up being used in similar places.