### PR TITLE
Implement equality checking with doubles

### DIFF
--- a/Numbers.Tests/RationalShould.cs
+++ b/Numbers.Tests/RationalShould.cs
@@ -78,6 +78,20 @@ namespace Numbers.Tests
             => Assert.True(One.Equals(1));
 
         [Fact]
+        public void HaveEqualsWorkWithBoxedDoubles()
+            => Assert.True(Half.Equals((object) 0.5));
+
+        [Fact]
+        public void HaveEqualsWorkWithDoubles()
+            => Assert.True((new Rational(1, 3)).Equals(1.00 / 3.00));
+
+        [Fact]
+        public void HaveEqualsNotWorkWithDoubles()
+            // This exposes the imprecision in doubles, and also the whole
+            // rationale behind using proper rationals.
+            => Assert.False(new Rational(1, 3).ToPower(3).Equals(Math.Pow(1.00 / 3.00, 3.00)));
+
+        [Fact]
         public void HaveEqualsHandleTypeMisMatch()
             => Assert.False(One.Equals(new Guid()));
 

--- a/Numbers/Rational.cs
+++ b/Numbers/Rational.cs
@@ -85,10 +85,12 @@ namespace Numbers
         {
             if (o is Rational r) return this == r;
             else if (o is int i) return this == i;
+            else if (o is double d) return (double) this == d;
             else return false;
         }
 
         public bool Equals(Rational r) => this == r;
+        public bool Equals(double d) => (double) this == d;
 
         private static int RaiseNumerator(Rational i, int newDenominator)
             => (i.Numerator * (newDenominator / i.Denominator));


### PR DESCRIPTION
This commit allows a user to, using the Equals methods, check for
equality between doubles and rationals that are casted to doubles for
the equality check. I'm hesitant about this, as it exposes the problems
inherent with using doubles, and I've added a test to show this.